### PR TITLE
Updates for Learned Indexes, NULLs are equal in DISTINCT but unequal in UNIQUE, fsyncgate & SERIAL is non-transactional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you're replicating SQL databases, whether MySQL, Postgres, or SQL Server, [ch
 - Battle Scars
   - Vectorized doesn't mean SIMD: *explanation needed*
   - join ordering is NP hard: *explanation needed*
-  - NULLs are equal in DISTINCT but inequal in UNIQUE: *explanation needed*
+  - NULLs are equal in DISTINCT but inequal in UNIQUE: https://modern-sql.com/feature/is-distinct-from
 
 
 ## Level 7

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you're replicating SQL databases, whether MySQL, Postgres, or SQL Server, [ch
   
 - Concepts
   - database cracking: *explanation needed*
-  - learned indexes: *explanation needed*
+  - learned indexes: https://www.postgresql.org/message-id/CAFcOn28TpR4oydF1NdMEuKFVVRiRwAwG4dGunu2kVxHZw3ViEA%40mail.gmail.com
   - XTID exhaustion: *explanation needed*
   - Worst Case Optimal Join: *explanation needed*
   - Volcano model: *explanation needed*

--- a/README.md
+++ b/README.md
@@ -119,5 +119,5 @@ If you're replicating SQL databases, whether MySQL, Postgres, or SQL Server, [ch
 - allballs: https://www.postgresql.org/message-id/24526.1106597936%40sss.pgh.pa.us
 - fsyncgate: https://wiki.postgresql.org/wiki/Fsync_Errors
 - Every SQL operator is actually a JOIN: *explanation needed*
-- SERIAL is non-transactional: *explanation needed*
+- SERIAL is non-transactional: https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL
 - NULL (?): *explanation needed*

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you're replicating SQL databases, whether MySQL, Postgres, or SQL Server, [ch
 - dee and dum: https://blog.jooq.org/creating-tables-dum-and-dee-in-postgresql/
 - the Halloween problem: https://en.wikipedia.org/wiki/Halloween_Problem
 - allballs: https://www.postgresql.org/message-id/24526.1106597936%40sss.pgh.pa.us
-- fsyncgate: *explanation needed*
+- fsyncgate: https://wiki.postgresql.org/wiki/Fsync_Errors
 - Every SQL operator is actually a JOIN: *explanation needed*
 - SERIAL is non-transactional: *explanation needed*
 - NULL (?): *explanation needed*


### PR DESCRIPTION
Added explanations in the commit messages, but most are self explanatory if you click through.

If it's not clear:

Learned Indexes appear to be a theoretical index, that hasn't been implemented in PostgreSQL, but is an interesting topic about the application of ML on datasets. The link provides many references. 

The NULL one is pretty self explanatory, the link provides a table of how NULL is treated differently in different contexts.

fsyncgate points in a wikipedia page that outlines the whole history of fsyncgate. 

SERIAL is technically non-transactional because when you rollback a transaction, SERIAL is still incremented outside of the transaction.